### PR TITLE
small text changes and fix unavailable video

### DIFF
--- a/controllers/assistant.php
+++ b/controllers/assistant.php
@@ -204,8 +204,8 @@ class AssistantController extends ToolAssistantBaseController
 
             <h2>Kommunikation im Kurs / Communication in the course</h2>
 
-            <p>... Beschreiben Sie hier, wie die Kommunikation im Kurs organisiert sein soll, z.B. in Form regelmäßiger Videokonferenzen, über ein Forum, den Blubber-Chat oder Matrix/Riot (s. "Online-Lehre: Online-Zusammenarbeit"). ...</p>
-            <p>... Describe here how communication in the course will be organised, e.g. in the form of regular video conferences, via a forum, the blubber chat or Matrix/Riot (see "Online teaching: online collaboration"). ...</p>
+            <p>... Beschreiben Sie hier, wie die Kommunikation im Kurs organisiert sein soll, z.B. in Form regelmäßiger Videokonferenzen, über ein Forum, den Blubber-Chat oder Matrix/Element (s. "Online-Lehre: Online-Zusammenarbeit"). ...</p>
+            <p>... Describe here how communication in the course will be organised, e.g. in the form of regular video conferences, via a forum, the blubber chat or Matrix/Element (see "Online teaching: online collaboration"). ...</p>
 
             <h2>Kontakt / Contact</h2>
 

--- a/views/de/assistant/copyright_info.php
+++ b/views/de/assistant/copyright_info.php
@@ -1,7 +1,7 @@
 <? if ($view === 'basics'): ?>
     <h2>Urheberrecht beachten: Die absoluten Grundlagen</h2>
     <div style="margin-left:10px;float:right">
-        <iframe width="320" height="180" src="https://www.youtube.com/embed/KxhL5ElJVLc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe width="320" height="180" src="https://www.youtube.com/embed/Bon7fmHC_BE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         <p style="font-size:66%"><i>ARD-alpha: Schutz vor Ideenklau - das Urheberrecht - so geht MEDIEN</i></p>
     </div>
     <p>

--- a/views/de/assistant/index.php
+++ b/views/de/assistant/index.php
@@ -412,10 +412,10 @@ Telefonnummer für Rückfragen:
                     <img src="<?= $plugin->getPluginURL() ?>/assets/studip-riot.jpg" width="160">
                 </div>
                 <p>Für Lern- und Arbeitsgruppen wird heute oft eine schnelle und niedrigschwellige Kommunikation gewünscht, auch per App vom Mobilgerät (Vorbild: Slack, Whatsapp).
-                    Die Uni Osnabrück bietet dafür den Dienst "Riot".</p>
+                    Die Uni Osnabrück bietet dafür den Dienst "Element".</p>
                 <ul>
                     <li>
-                        <a href="https://www.rz.uni-osnabrueck.de/homeoffice/riot.html" class="link-extern" target="_blank">So geht's: Matrix/Riot einrichten (RZ)</a>
+                        <a href="https://www.rz.uni-osnabrueck.de/homeoffice/riot.html" class="link-extern" target="_blank">So geht's: Matrix/Element einrichten (RZ)</a>
                     </li>
                     <li>
                         <a href="<?= $controller->link_for('assistant/messenger_info/blubber') ?>" data-dialog="size=640x500">Alternative in Stud.IP: Blubber-Chat</a>

--- a/views/en/assistant/index.php
+++ b/views/en/assistant/index.php
@@ -418,10 +418,10 @@ Phone number for questions:
                     <img src="<?= $plugin->getPluginURL() ?>/assets/studip-riot.jpg" width="160">
                 </div>
                 <p>Fast and low-threshold communication is a common request nowadays, also via an app from mobile devices (like Slack or Whatsapp).
-                    Osnabrück University offers the "Riot" service for this purpose.
+                    Osnabrück University offers the "Element" service for this purpose.
                 <ul>
                     <li>
-                        <a href="https://www.rz.uni-osnabrueck.de/homeoffice/riot.html" class="link-external" target="_blank">Guide: Set up Matrix/Riot (RZ)</a>
+                        <a href="https://www.rz.uni-osnabrueck.de/homeoffice/riot.html" class="link-external" target="_blank">Guide: Set up Matrix/Element (RZ)</a>
                     </li>
                     <li>
                         <a href="<?= $controller->link_for('assistant/messenger_info/blubber') ?>" data-dialog="size=640x500">An alternative in Stud.IP: Blubber chat</a>


### PR DESCRIPTION
Ein paar einfache Textanpassungen. Riot -> Element und das Copyright Video war nicht mehr verfügbar, es wurde wohl neu hochgeladen (oder es ist nicht ganz dasselbe Video, ist aber auch von ARD-alpha / So Geht Medien).